### PR TITLE
refactor: remove flattening option from compile methods and update re…

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ ThinkAgain is a minimal, debuggable agent framework for building explicit pipeli
 - **Graph-first architecture** – everything inherits from `Executable`, so workers, graphs, and pipelines compose naturally with `>>`.
 - **Async core, sync friendly** – all executables expose `arun(ctx)`; synchronous calls simply wrap that single code path.
 - **Deterministic Context** – one `Context` object carries state, metadata, and execution history through the system.
-- **First-class introspection** – `Graph.visualize()`, `Graph.to_dict()`, `graph.compile(flatten=True)`, and `ctx.history` reveal plans before and after they run.
+- **First-class introspection** – `Graph.visualize()`, `Graph.to_dict()`, `graph.compile()`, and `ctx.history` reveal plans before and after they run.
 - **Minimal surface area** – just Python classes; no DSLs, no sidecar runtime, and no hidden orchestration layers.
 
 ## Architecture at a Glance
@@ -139,7 +139,7 @@ coordinator.add_edge("research", "write")
 
 - `Context.history` records every log message emitted by workers and graph nodes.
 - `ctx.to_dict()` (or duck-typing with `ctx["key"]`) shows the exact state shuttled between stages.
-- `Graph.visualize()` renders a Mermaid diagram; `Graph.to_dict()` and `graph.compile(flatten=True)` produce machine-readable plans.
+- `Graph.visualize()` renders a Mermaid diagram; `Graph.to_dict()` and `graph.compile()` produce machine-readable plans.
 - `examples/minimal_demo.py` prints both the execution logs and a Mermaid graph so you can watch the state evolve.
 
 ## Examples

--- a/examples/minimal_demo.py
+++ b/examples/minimal_demo.py
@@ -183,7 +183,7 @@ async def composition_and_compile_demo() -> None:
     generation = build_generation_stage()
 
     composed = retrieval >> generation
-    compiled = composed.compile(flatten=True)
+    compiled = composed.compile()
 
     ctx = Context(query="compilation benefits", top_n=2)
     result = await compiled.arun(ctx)

--- a/tests/test_execution_cycles.py
+++ b/tests/test_execution_cycles.py
@@ -2,8 +2,6 @@
 
 import asyncio
 
-import pytest
-
 from thinkagain.core.context import Context
 from thinkagain.core.graph import END, Graph
 from thinkagain.core.worker import Worker
@@ -59,25 +57,13 @@ def test_non_compiled_cycle() -> None:
     _assert_three_iterations(ctx)
 
 
-def test_compiled_nested_cycle() -> None:
-    compiled = _build_cycle_graph().compile(flatten=False)
-    ctx = _run(compiled)
-    _assert_three_iterations(ctx)
-
-
-def test_compiled_flat_cycle() -> None:
-    compiled = _build_cycle_graph().compile(flatten=True)
+def test_compiled_cycle() -> None:
+    compiled = _build_cycle_graph().compile()
     ctx = _run(compiled)
     _assert_three_iterations(ctx)
 
 
 def test_nested_subgraph_with_cycle() -> None:
-    compiled = _build_nested_graph().compile(flatten=False)
-    ctx = _run(compiled)
-    assert ctx.count == 3
-
-
-def test_flattened_subgraph_with_cycle() -> None:
-    compiled = _build_nested_graph().compile(flatten=True)
+    compiled = _build_nested_graph().compile()
     ctx = _run(compiled)
     assert ctx.count == 3

--- a/tests/test_self_reference.py
+++ b/tests/test_self_reference.py
@@ -29,7 +29,7 @@ def test_direct_self_reference_raises_value_error() -> None:
     graph.set_entry("worker")
 
     with pytest.raises(ValueError, match=re.compile("cycle detected", re.IGNORECASE)):
-        graph.compile(flatten=True)
+        graph.compile()
 
 
 def test_indirect_self_reference_is_detected() -> None:
@@ -48,7 +48,7 @@ def test_indirect_self_reference_is_detected() -> None:
     g2.set_entry("g1")
 
     with pytest.raises(ValueError, match=re.compile("cycle detected", re.IGNORECASE)):
-        g1.compile(flatten=True)
+        g1.compile()
 
 
 def test_normal_nested_graph_compiles() -> None:
@@ -67,5 +67,5 @@ def test_normal_nested_graph_compiles() -> None:
     outer.add_edge("subgraph", END)
     outer.set_entry("w1")
 
-    compiled = outer.compile(flatten=True)
+    compiled = outer.compile()
     assert "subgraph__w2" in compiled.nodes

--- a/thinkagain/core/compiled_graph.py
+++ b/thinkagain/core/compiled_graph.py
@@ -10,7 +10,6 @@ The compilation pattern separates graph construction from execution:
 
 Benefits:
 - Validate once at compile time, not on every execution
-- Support multiple execution strategies (nested vs flat)
 - Enable compile-time optimizations
 - Clear separation of concerns
 """
@@ -48,7 +47,6 @@ class CompiledGraph:
         edges: Dict[str, EdgeTarget],
         entry_point: str,
         max_steps: Optional[int] = None,
-        is_flattened: bool = False,
     ):
         """
         Initialize compiled graph.
@@ -59,14 +57,12 @@ class CompiledGraph:
             edges: Mapping of node names to edge targets
             entry_point: Starting node
             max_steps: Optional step limit
-            is_flattened: Whether subgraphs have been inlined
         """
         self.name = name
         self.nodes = nodes
         self.edges = edges
         self.entry_point = entry_point
         self.max_steps = max_steps
-        self.is_flattened = is_flattened
 
         # Make immutable (shallow - prevents adding/removing nodes)
         self._sealed = True
@@ -84,11 +80,7 @@ class CompiledGraph:
         Raises:
             ValueError: If execution fails
         """
-        prefix = (
-            f"[CompiledGraph:{self.name}]"
-            if self.is_flattened
-            else f"[Graph:{self.name}]"
-        )
+        prefix = f"[CompiledGraph:{self.name}]"
         return await execute_graph(
             ctx=ctx,
             nodes=self.nodes,
@@ -111,7 +103,4 @@ class CompiledGraph:
         return generate_mermaid_diagram(self.nodes, self.edges, self.entry_point)
 
     def __repr__(self) -> str:
-        mode = "flat" if self.is_flattened else "nested"
-        return (
-            f"CompiledGraph(name='{self.name}', nodes={len(self.nodes)}, mode='{mode}')"
-        )
+        return f"CompiledGraph(name='{self.name}', nodes={len(self.nodes)})"

--- a/thinkagain/core/executable.py
+++ b/thinkagain/core/executable.py
@@ -101,7 +101,7 @@ class Executable:
 
         To flatten subgraphs, use compile():
             pipeline = worker1 >> subgraph >> worker2
-            flat = pipeline.compile(flatten=True)
+            flat = pipeline.compile()
 
         Args:
             other: Next executable in the chain
@@ -117,7 +117,7 @@ class Executable:
             result = await pipeline.arun(ctx)
 
             # Or compile flat for debugging
-            flat = pipeline.compile(flatten=True)
+            flat = pipeline.compile()
             print(flat.visualize())
         """
         from .graph import Graph, END


### PR DESCRIPTION
…lated documentation

- `compile` no longer supports nested graph. All graphs are flatten by default.