### PR TITLE
Ensure jsonschema is required when validating structured outputs, tig…

### DIFF
--- a/examples/minimal_demo.py
+++ b/examples/minimal_demo.py
@@ -170,7 +170,7 @@ def build_retrieval_stage() -> Graph:
     return RetrieveDocs() >> RerankDocs()
 
 
-def build_generation_stage() -> Graph:
+def build_generation_stage() -> Worker:
     return GenerateAnswer()
 
 

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 
 import asyncio
 
-from thinkagain import Context, Executable, Graph, Worker, END
+from thinkagain import Context, Graph, Worker, END
+from thinkagain.core.graph_executor import GraphExecutor
 
 
 class Appender(Worker):
@@ -26,7 +27,7 @@ def _build_linear_graph() -> Graph:
 
 
 async def _gather_events(
-    executable: "Executable",
+    executable: GraphExecutor,
 ) -> tuple[Context, list[tuple[str, str | None, list[str]]]]:
     ctx = Context()
     events = []

--- a/thinkagain/core/executable.py
+++ b/thinkagain/core/executable.py
@@ -30,7 +30,7 @@ class Executable:
     Everything is composable with everything.
     """
 
-    def __init__(self, name: str = None):
+    def __init__(self, name: str | None = None):
         """
         Initialize executable with a name.
 

--- a/thinkagain/core/graph.py
+++ b/thinkagain/core/graph.py
@@ -237,21 +237,6 @@ class Graph(GraphExecutor):
 
         return reachable
 
-    def visualize(self) -> str:
-        """
-        Generate Mermaid diagram syntax for the graph.
-
-        Returns:
-            Mermaid diagram code that can be rendered or saved
-
-        Example:
-            print(graph.visualize())
-            # Copy output to mermaid.live or GitHub markdown
-        """
-        from .visualization import generate_mermaid_diagram
-
-        return generate_mermaid_diagram(self.nodes, self.edges, self.entry_point)
-
     def compile(self) -> "CompiledGraph":
         """
         Compile graph into an optimized, flattened representation.

--- a/thinkagain/core/runtime.py
+++ b/thinkagain/core/runtime.py
@@ -12,7 +12,17 @@ from __future__ import annotations
 
 import asyncio
 from dataclasses import dataclass
-from typing import Any, AsyncIterator, Callable, Dict, Literal, Optional, Union
+from collections.abc import Awaitable as AwaitableABC
+from typing import (
+    Any,
+    Awaitable,
+    AsyncIterator,
+    Callable,
+    Dict,
+    Literal,
+    Optional,
+    Union,
+)
 
 from .context import Context
 
@@ -281,10 +291,13 @@ async def _invoke(node: Any, ctx: Context) -> Context:
     return await asyncio.to_thread(node, ctx)
 
 
-async def _call_route(route: Callable[[Context], str], ctx: Context) -> str:
-    if asyncio.iscoroutinefunction(route):
-        return await route(ctx)
-    return route(ctx)
+async def _call_route(
+    route: Callable[[Context], str | Awaitable[str]], ctx: Context
+) -> str:
+    result = route(ctx)
+    if isinstance(result, AwaitableABC):
+        return await result
+    return result
 
 
 __all__ = [

--- a/thinkagain/core/worker.py
+++ b/thinkagain/core/worker.py
@@ -68,7 +68,7 @@ class Worker(Executable):
             print(ctx_snapshot.response)  # See incremental updates
     """
 
-    def __init__(self, name: str = None):
+    def __init__(self, name: str | None = None):
         """
         Initialize worker with a name.
 

--- a/thinkagain/serve/openai/serve_completion.py
+++ b/thinkagain/serve/openai/serve_completion.py
@@ -280,6 +280,13 @@ def _validate_structured_response(text: str, fmt: NormalizedResponseFormat):
             "Structured output schema missing at validation time.", status_code=500
         )
 
+    if jsonschema_validate is None:
+        raise _openai_error(
+            "jsonschema package required for structured output validation. "
+            "Install with: pip install jsonschema",
+            status_code=500,
+        )
+
     try:
         jsonschema_validate(instance=parsed, schema=schema_body)
     except ValidationError as exc:  # type: ignore[misc]


### PR DESCRIPTION
…hten type annotations (async routes, optional names, Worker return from build_generation_stage), update streaming tests to use GraphExecutor, and drop the unused Graph.visualize convenience helper.